### PR TITLE
Made improvements to cache storage classes

### DIFF
--- a/core/Pimf/Cache.php
+++ b/core/Pimf/Cache.php
@@ -48,6 +48,11 @@ class Cache
      */
     public static function storage($storage = 'memory')
     {
+        $conf = Config::get('cache.storage');
+        if ($conf !== null) {
+            $storage = $conf;
+        }
+
         if (!isset(static::$storages[$storage])) {
             static::$storages[$storage] = static::factory($storage);
         }

--- a/core/Pimf/Cache.php
+++ b/core/Pimf/Cache.php
@@ -46,11 +46,10 @@ class Cache
      *
      * @return CS\Apc|CS\Dba|CS\File|CS\Memcached|CS\Memory|CS\Pdo|CS\Redis|CS\WinCache
      */
-    public static function storage($storage = 'memory')
+    public static function storage($storage = null)
     {
-        $conf = Config::get('cache.storage');
-        if ($conf !== null) {
-            $storage = $conf;
+        if ($storage === null) {
+            $storage = Config::get('cache.storage') ?: 'memory';
         }
 
         if (!isset(static::$storages[$storage])) {

--- a/core/Pimf/Cache/Storages/Dba.php
+++ b/core/Pimf/Cache/Storages/Dba.php
@@ -103,7 +103,7 @@ class Dba extends Storage
             return;
         }
 
-        $value = $this->expiration($minutes) . serialize($value);
+        $value = self::expiration($minutes) . serialize($value);
 
         if (true === $this->has($key)) {
             return dba_replace($key, $value, $this->dba);

--- a/core/Pimf/Cache/Storages/Pdo.php
+++ b/core/Pimf/Cache/Storages/Pdo.php
@@ -84,7 +84,7 @@ class Pdo extends Storage
     {
         $key = $this->key . $key;
         $value = serialize($value);
-        $expiration = $this->expiration($minutes);
+        $expiration = self::expiration($minutes);
 
         try {
             $sth = $this->pdo->prepare(

--- a/core/Pimf/Cache/Storages/Storage.php
+++ b/core/Pimf/Cache/Storages/Storage.php
@@ -12,7 +12,7 @@ namespace Pimf\Cache\Storages;
  * @package Cache_Storages
  * @author  Gjero Krsteski <gjero@krsteski.de>
  */
-abstract class Storage
+abstract class Storage implements \ArrayAccess
 {
     /**
      * Determine if an item exists in the cache.
@@ -24,6 +24,20 @@ abstract class Storage
     public function has($key)
     {
         return ($this->get($key) !== null);
+    }
+
+    /**
+     * Determine if an item exists in the cache.
+     *
+     * Enables you to use: isset($storage[$key])
+     *
+     * @param $offset
+     *
+     * @return bool
+     */
+    public function offsetExists($offset)
+    {
+        return $this->has($offset);
     }
 
     /**
@@ -45,6 +59,25 @@ abstract class Storage
     public function get($key, $default = null)
     {
         return (!is_null($item = $this->retrieve($key))) ? $item : $default;
+    }
+
+    /**
+     * Get an item from the cache.
+     *
+     * Enables you to use: $storage[$key]
+     *
+     * <code>
+     *    // Get an item from the cache storage
+     *    $name = Cache::storage()['name'];
+     * </code>
+     *
+     * @param      $offset
+     *
+     * @return mixed|null
+     */
+    public function offsetGet($offset)
+    {
+        return $this->get($offset);
     }
 
     /**
@@ -71,6 +104,19 @@ abstract class Storage
      * @return void
      */
     abstract public function put($key, $value, $minutes);
+
+    /**
+     * Write an item to the cache for indefinite-term storage.
+     *
+     * Enables you to use: $storage[$key] = $value;
+     *
+     * @param $key
+     * @param $value
+     */
+    public function offsetSet($key, $value)
+    {
+        $this->forever($key, value);
+    }
 
     /**
      * Get an item from the cache, or cache and return the default value.
@@ -102,6 +148,16 @@ abstract class Storage
     }
 
     /**
+     * Write an item to the cache for indefinite-term storage.
+     *
+     * @param $key
+     * @param $value
+     *
+     * @return mixed Depends on implementation
+     */
+    abstract public function forever($key, $value);
+
+    /**
      * Get an item from the cache, or cache the default value forever.
      *
      * @param string $key
@@ -124,13 +180,25 @@ abstract class Storage
     abstract public function forget($key);
 
     /**
+     * Delete an item from the cache.
+     *
+     * Enables you to use: unset($storage[$key]);
+     *
+     * @param string $key
+     */
+    public function offsetUnset($key)
+    {
+        $this->forget($key);
+    }
+
+    /**
      * Get the expiration time as a UNIX timestamp.
      *
      * @param int $minutes
      *
      * @return int
      */
-    protected function expiration($minutes)
+    protected static function expiration($minutes)
     {
         return time() + ($minutes * 60);
     }


### PR DESCRIPTION
... in preparation for adding an adapter for another templating engine.

- The change in `Cache::storage()` makes it look for a default storage engine in the configuration before using the hard-coded default of 'memory'.
- Added the method `File::has()` to avoid unnecessary method calls from the parent class.
- **[IMPORTANT]** The `File::retrieve()` method previously returned `true` if the cache file had expired. This looks like a flaw to me because it is also possible for `true` to be the value cached in the file. Therefore, I made it return `null` instead, just as if the cache file didn't exist. (And returning the result of `forget()` was pointless because we already know it will be `true`.) See issue #25 also.
- Implemented `\ArrayAccess` in `Storage` class so that it can be used like an array, since all of the child classes are key-value stores.
- Marked `Storage::expiration()` as static since it doesn't reference `$this`