### PR TITLE
Added adapter for Transphporm template engine

### DIFF
--- a/autoload.core.php
+++ b/autoload.core.php
@@ -99,7 +99,7 @@ spl_autoload_register(
                 'Pimf\\Util\\Xml'                    => '/Pimf/Util/Xml.php',
                 'Pimf\\View'                         => '/Pimf/View.php',
                 'Pimf\\View\\Haanga'                 => '/Pimf/View/Haanga.php',
-                'Pimf\\View\\Json'                   => '/Pimf/View/Json.php',
+                'Pimf\\View\\Transphporm'            => '/Pimf/View/Transphporm.php',
                 'Pimf\\View\\Twig'                   => '/Pimf/View/Twig.php'
             );
         }

--- a/core/Pimf/View/Transphporm.php
+++ b/core/Pimf/View/Transphporm.php
@@ -67,9 +67,16 @@ class Transphporm extends View implements Reunitable
      */
     public function reunite()
     {
+        $tss = $this->data['tss'];
+        $tsspath = $this->path . '/' . $tss;
+
+        if (is_file($tsspath)) {
+            $tss = $tsspath;
+        }
+
         $template = new \Transphporm\Builder(
             $this->path . '/' . $this->template,
-            $this->path . '/' . $this->data['tss']
+            $tss
         );
 
         if (isset($this->cache)) {

--- a/core/Pimf/View/Transphporm.php
+++ b/core/Pimf/View/Transphporm.php
@@ -70,13 +70,9 @@ class Transphporm extends View implements Reunitable
         $tss = $this->data['tss'];
         $tsspath = $this->path . '/' . $tss;
 
-        if (is_file($tsspath)) {
-            $tss = $tsspath;
-        }
-
         $template = new \Transphporm\Builder(
             $this->path . '/' . $this->template,
-            $tss
+            (is_file($tsspath)) ? $tsspath : $tss
         );
 
         if (isset($this->cache)) {

--- a/core/Pimf/View/Transphporm.php
+++ b/core/Pimf/View/Transphporm.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * View
+ *
+ * @copyright Copyright (c)  Garrett Whitehorn (http://garrettw.net/)
+ * @license   http://opensource.org/licenses/MIT MIT License
+ */
+
+namespace Pimf\View;
+
+use Pimf\Contracts\Reunitable;
+use Pimf\View;
+use Pimf\Config;
+use Pimf\Cache\Storages\File as FileCache;
+
+/**
+ * A view for the Transphporm template engine which uses CSS-style syntax and
+ * separates templates from data logic.
+ *
+ * For use please add the following code to the end of the config.app.php file:
+ *
+ * <code>
+ *
+ * 'view' => array(
+ *
+ *   'transphporm' => array(
+ *     'cache'       => true,  // if compilation caching should be used
+ *   ),
+ *
+ * ),
+ *
+ * </code>
+ *
+ * @link    https://github.com/Level-2/Transphporm
+ * @package View
+ * @author  Garrett Whitehorn <gw@garrettw.net>
+ * @codeCoverageIgnore
+ */
+class Transphporm extends View implements Reunitable
+{
+    /**
+     * @var \Pimf\Cache\Storages\File
+     */
+    protected $cache;
+
+    /**
+     * @param string $template
+     * @param array  $data
+     */
+    public function __construct($template, array $data = [])
+    {
+        parent::__construct($template, $data);
+
+        $conf = Config::get('view.transphporm');
+
+        if ($conf['cache'] === true) {
+            $this->cache = new FileCache($this->path . '/transphporm_cache/');
+        }
+
+        require_once BASE_PATH . "Transphporm/vendor/autoload.php";
+    }
+
+    /**
+     * Puts the template and the TSS/data together.
+     *
+     * @return string
+     */
+    public function reunite()
+    {
+        $template = new \Transphporm\Builder(
+            $this->path . '/' . $this->template,
+            $this->path . '/' . $this->data['tss']
+        );
+
+        if (isset($this->cache)) {
+            $template->setCache($this->cache);
+        }
+
+        if (isset($this->data['data'])) {
+            return $template->output($this->data['data'])->body;
+        }
+        return $template->output()->body;
+    }
+}


### PR DESCRIPTION
[Level-2/Transphporm](/Level-2/Transphporm) is my favorite templating engine, so I made an adapter for Pimf so that I could use them together.
Please note that the underlying API is slightly different from Twig and Haanga.
Here is an example of the API using code from the Twig/Haanga app templates.
```php
$view = new View('blog.xml', [
    'tss' => 'hello.tss',
    'data' => [    // the 'data' param is optional; depends on whether your TSS file requires it
        'blog_title'   => 'Welcome to PIMF Twig bundle',
        'blog_content' => 'Hello '.join(' ', (array)$firstname).'!!!',
        'blog_footer'  => 'Please type at the URL "/hello/Barry" and see what happens!',
    ]
]);
```

Here is the content of `hello.tss`. Of course, this is a very simplified example and Transphporm is capable of much more.
```css
title, header h1 { content: data(blog_title); }
h2 { content: data(blog_content); }
footer p strong { content: data(blog_footer); }
```

And finally, here is the content of `blog.xml` just to show what's going on.
```xml
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="utf-8" />
    <title>This title will be replaced by Transphporm.</title>
</head>
<body>
  <header>
      <h1>You will never see this blog title text</h1>
  </header>
  <h2>Here is some lorem ipsum text for the blog content.</h2>
  <footer>
        <p>
          <strong>Some footer text just to test it with.</strong>
        </p>
  </footer>
</body>
</html>
```